### PR TITLE
Experimental support for embedded source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var through = require('through2');
 var fs = require('fs');
 var path = require('path');
 var File = require('vinyl');
+var convert = require('convert-source-map');
 
 var PLUGIN_NAME = 'gulp-sourcemap';
 
@@ -22,8 +23,7 @@ module.exports.init = function init() {
       return callback(new Error(PLUGIN_NAME + ': Streaming not supported'));
     }
 
-    // initialize source map
-    file.sourceMap = {
+    var map = {
       version : 3,
       file: file.relative,
       names: [],
@@ -32,6 +32,9 @@ module.exports.init = function init() {
       sourcesContent: [file.contents.toString()]
     };
 
+    var embeddedMap = convert.fromSource(file.contents.toString());
+
+    file.sourceMap = embeddedMap ? embeddedMap.toObject() : map;
     this.push(file);
     callback();
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "license": "ISC",
   "dependencies": {
     "through2": "^0.4.1",
-    "vinyl": "^0.2.3"
+    "vinyl": "^0.2.3",
+    "convert-source-map": "^0.3.3"
   },
   "devDependencies": {
     "jshint": "^2.5.0",


### PR DESCRIPTION
~~It's barely working but I wanted to get input on it as soon as possible.~~
I'm using [convert-source-map](https://github.com/thlorenz/convert-source-map) now. Here's an example gulp task:

``` javascript
gulp.task('scripts', function() {
  var bundler = watchify(path.join(__dirname, 'app/scripts/main.js'));

  bundler.on('update', rebundle);

  function rebundle() {
    return bundler.bundle({ debug: true })
      .pipe(source('all.js'))
      .pipe(streamify(sourcemaps.init()))
      .pipe(streamify(uglify()))
      .pipe(streamify(sourcemaps.write('.')))
      .pipe(gulp.dest(path.join(__dirname, 'out/assets')));
  }

  return rebundle();
});
```
