### PR TITLE
fix sourceRoot

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports.write = function write(destPath, options) {
     sourceMap.file = file.relative;
 
     if (options.sourceRoot)
-      sourceMap.sourceRoot = options.sourceRoot;
+      sourceMap.sourceRoot = path.join(options.sourceRoot, path.dirname(file.relative));
 
     if (options.includeContent) {
       sourceMap.sourceRoot = options.sourceRoot || '/source/';


### PR DESCRIPTION
My project structure:
coffee
--folder1
----0.coffee
----folder2
------1.coffee
------2.coffee

js
--folder1
----0.js
----folder2
------1.js
------2.js

if I use plugin with options `sourcemaps.write('./', {includeContent: false, sourceRoot: 'coffee' }` I get error in browser while debugging "coffee/folder1/folder2/1.coffee not found", chrome looking for source in root of coffee folder.
