### PR TITLE
Allow defining sourceRoot per file

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ gulp.task('javascript', function() {
 
 - `sourceRoot`
 
-  Set the path where the source files are hosted (use this when `includeContent` is set to `false`). This is an URL (or subpath) relative to the source map, not a local file system path. If you have sources in different subpaths, an absolute path (from the domain root) pointing to the source file root is recommended.
+  Set the path where the source files are hosted (use this when `includeContent` is set to `false`). This is an URL (or subpath) relative to the source map, not a local file system path. If you have sources in different subpaths, an absolute path (from the domain root) pointing to the source file root is recommended, or define it with a function.
 
   Example:
   ```javascript

--- a/index.js
+++ b/index.js
@@ -141,11 +141,17 @@ module.exports.write = function write(destPath, options) {
     var sourceMap = file.sourceMap;
     sourceMap.file = file.relative;
 
-    if (options.sourceRoot)
-      sourceMap.sourceRoot = options.sourceRoot;
+    if (options.sourceRoot) {
+      if (typeof options.sourceRoot === 'function') {
+        sourceMap.sourceRoot = options.sourceRoot(file);
+      } else {
+        sourceMap.sourceRoot = options.sourceRoot;
+      }
+
+    }
 
     if (options.includeContent) {
-      sourceMap.sourceRoot = options.sourceRoot || '/source/';
+      sourceMap.sourceRoot = sourceMap.sourceRoot || '/source/';
       sourceMap.sourcesContent = sourceMap.sourcesContent || [];
 
       // load missing source content

--- a/test/write.js
+++ b/test/write.js
@@ -238,3 +238,16 @@ test('write: should set the sourceRoot by option sourceRoot', function(t) {
         })
         .write(file);
 });
+
+test('write: should set the sourceRoot by option sourceRoot, as a function', function(t) {
+    var file = makeFile();
+    var pipeline = sourcemaps.write({
+      sourceRoot: function(file) { return '/testSourceRoot'; }
+    });
+    pipeline
+        .on('data', function(data) {
+            t.equal(data.sourceMap.sourceRoot, '/testSourceRoot', 'should set sourceRoot');
+            t.end();
+        })
+        .write(file);
+});


### PR DESCRIPTION
It could be great to define sourceRoot per file, to avoid absolute path
