### PR TITLE
accept prefix option in #write

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,26 @@ gulp.task('javascript', function() {
   });
   ```
 
+- `sourceMappingURLPrefix`
+
+  Specify a prefix to be prepended onto the source map URL when writing external source maps. Relative paths will have their leading dots stripped.
+
+  Example:
+  ```javascript
+  gulp.task('javascript', function() {
+    var stream = gulp.src('src/**/*.js')
+      .pipe(sourcemaps.init())
+        .pipe(concat('all.js'))
+        .pipe(uglify())
+      .pipe(sourcemaps.write('../maps', {
+        sourceMappingURLPrefix: 'https://asset-host.example.com/assets'
+      }))
+      .pipe(gulp.dest('public/scripts'));
+  });
+  ```
+
+  This will result in source mapping URL comment like `sourceMappingURL=https://asset-host.example.com/assets/maps/helloworld.js.map`.
+
 ### Plugin developers only: How to add source map support to plugins
 
 - Generate a source map for the transformation the plugin is applying

--- a/index.js
+++ b/index.js
@@ -200,8 +200,8 @@ module.exports.write = function write(destPath, options) {
 
       comment = commentFormatter(path.join(path.relative(path.dirname(file.path), file.base), destPath, file.relative) + '.map');
 
-      if (options.prefix) {
-        comment = comment.replace('sourceMappingURL=', 'sourceMappingURL=' + options.prefix);
+      if (options.sourceMappingURLPrefix) {
+        comment = comment.replace(/sourceMappingURL=\.*/, 'sourceMappingURL=' + options.sourceMappingURLPrefix);
       }
     }
 

--- a/test/write.js
+++ b/test/write.js
@@ -251,3 +251,17 @@ test('write: should set the sourceRoot by option sourceRoot, as a function', fun
         })
         .write(file);
 });
+
+test('write: should accept a sourceMappingURLPrefix', function(t) {
+    var file = makeFile();
+    var pipeline = sourcemaps.write('../maps', { sourceMappingURLPrefix: 'https://asset-host.example.com' });
+    pipeline
+      .on('data', function(data) {
+        if (/helloworld\.js$/.test(data.path)) {
+          t.equal(String(data.contents).match(/sourceMappingURL.*$/)[0],
+            'sourceMappingURL=https://asset-host.example.com/maps/helloworld.js.map');
+          t.end();
+        }
+      })
+      .write(file);
+});


### PR DESCRIPTION
Frequently, a full URL to a sourcemap is needed for `sourceMappingURL`. This simply adds a `prefix` option which will be prepended to the automatically generated URL.
