### PR TITLE
Fix slashes in sources path for Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports.init = function init(options) {
         sourceMap.sourcesContent = sourceMap.sourcesContent || [];
         sourceMap.sources.forEach(function(source, i) {
           var absPath = path.resolve(sourcePath, source);
-          sourceMap.sources[i] = path.relative(file.base, absPath);
+          sourceMap.sources[i] = path.relative(file.base, absPath).replace('\\', '/');
 
           if (!sourceMap.sourcesContent[i]) {
             var sourceContent = null;


### PR DESCRIPTION
When using Windows, paths to sources should use forward slashes anyway or it will work slightly incorrectly (with workspace mapping in Chrome, for example).
