### PR TITLE
Fix to use file.path instead of file.base - Fixes #30

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ module.exports.write = function write(destPath, options) {
       // load missing source content
       for (var i = 0; i < file.sourceMap.sources.length; i++) {
         if (!sourceMap.sourcesContent[i]) {
-          var sourcePath = path.resolve(file.base, sourceMap.sources[i]);
+          var sourcePath = path.resolve(path.dirname(file.path), sourceMap.sources[i]);
           try {
             sourceMap.sourcesContent[i] = fs.readFileSync(sourcePath).toString();
           } catch (e) {


### PR DESCRIPTION
Fix that file.base returns the base from where the file glob starts searching, but the path should be where the file is instead.
