### PR TITLE
Deprecate options.mapSources and export mapSources stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,27 @@ gulp.src(['src/test.js', 'src/testdir/test2.js'], { base: 'src' })
 });
 ```
 
+#### Alter `sources` property on sourcemaps
+
+The exported `mapSources` method gives full control over the source paths. It takes a function that is called for every source and receives the default source path as a parameter and the original vinyl file.
+
+Example:
+```javascript
+gulp.task('javascript', function() {
+  var stream = gulp.src('src/**/*.js')
+    .pipe(sourcemaps.init())
+      .pipe(plugin1())
+      .pipe(plugin2())
+      // be careful with the sources returned otherwise contents might not be loaded properly
+      .pipe(sourcemaps.mapSources(function(sourcePath, file) {
+        // source paths are prefixed with '../src/'
+        return '../src/' + sourcePath;
+      }))
+    .pipe(sourcemaps.write('../maps')
+    .pipe(gulp.dest('public/scripts'));
+});
+```
+
 
 
 ### Init Options
@@ -277,24 +298,7 @@ gulp.src(['src/test.js', 'src/testdir/test2.js'], { base: 'src' })
 
 - `mapSources`
 
-  This option gives full control over the source paths. It takes a function that is called for every source and receives the default source path as a parameter and the original vinyl file.
-
-  Example:
-  ```javascript
-  gulp.task('javascript', function() {
-    var stream = gulp.src('src/**/*.js')
-      .pipe(sourcemaps.init())
-        .pipe(plugin1())
-        .pipe(plugin2())
-      .pipe(sourcemaps.write('../maps', {
-        mapSources: function(sourcePath, file) {
-          // source paths are prefixed with '../src/'
-          return '../src/' + sourcePath;
-        }
-      }))
-      .pipe(gulp.dest('public/scripts'));
-  });
-  ```
+  __This option is deprecated. Upgrade to use our [`sourcemap.mapSources`](#alter-sources-property-on-sourcemaps) API.__
 
 - `charset`
 

--- a/index.js
+++ b/index.js
@@ -2,5 +2,6 @@
 
 module.exports = {
   init: require('./src/init'),
-  write: require('./src/write')
+  write: require('./src/write'),
+  mapSources: require('@gulp-sourcemaps/map-sources')
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "Florian Reiterer <me@florianreiterer.com>",
   "license": "ISC",
   "dependencies": {
+    "@gulp-sourcemaps/map-sources": "1.X",
     "acorn": "4.X",
     "convert-source-map": "1.X",
     "css": "2.X",
@@ -48,6 +49,7 @@
     "istanbul": "0.X",
     "jshint": "2.X",
     "lodash": "4.17.4",
+    "mississippi": "^1.3.0",
     "object-assign": "^4.1.0",
     "tape": "4.X",
     "yargs": "6.6.0"

--- a/src/write/index.internals.js
+++ b/src/write/index.internals.js
@@ -36,7 +36,9 @@ module.exports = function(destPath, options) {
 
     //NOTE: make sure source mapping happens after content has been loaded
     if (options.mapSources && typeof options.mapSources === 'function') {
+      debug(utils.logCb('**Option is deprecated, update to use sourcemap.mapSources stream**'));
       debug(utils.logCb('function'));
+
       file.sourceMap.sources = file.sourceMap.sources.map(function (filePath) {
         return options.mapSources(filePath, file);
       });


### PR DESCRIPTION
@nmccready How do you feel about this deprecation and recommended change?  I'm not sure why the tests are failing because they were failing when I pulled the repo down (likely a dependency change).