### PR TITLE
Deprecate options.identityMap and export identityMap stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,23 @@ gulp.task('javascript', function() {
 });
 ```
 
+#### Generate Identity Sourcemap
+
+The exported `identityMap` method allows you to generate a full valid source map encoding no changes (slower, only for Javascript and CSS) instead of the default empty source map (no mappings, fast). __Use this option if you get missing or incorrect mappings, e.g. when debugging.__
+
+Example:
+```javascript
+gulp.task('javascript', function() {
+  var stream = gulp.src('src/**/*.js')
+    .pipe(sourcemaps.init())
+      // An identity sourcemap will be generated at this step
+      .pipe(sourcemaps.identityMap())
+      .pipe(plugin1())
+      .pipe(plugin2())
+    .pipe(sourcemaps.write('../maps')
+    .pipe(gulp.dest('public/scripts'));
+});
+```
 
 
 ### Init Options
@@ -148,9 +165,7 @@ gulp.task('javascript', function() {
 
 - `identityMap`
 
-  Set to true to generate a full valid source map encoding no changes (slower, only
-  for Javascript and CSS) instead of the default empty source map (no mappings, fast).
-  Use this option if you get missing or incorrect mappings, e.g. when debugging.
+  __This option is deprecated. Upgrade to use our [`sourcemap.identityMap`](#generate-identity-sourcemap) API.__
 
 
 ### Write Options

--- a/index.js
+++ b/index.js
@@ -3,5 +3,6 @@
 module.exports = {
   init: require('./src/init'),
   write: require('./src/write'),
-  mapSources: require('@gulp-sourcemaps/map-sources')
+  mapSources: require('@gulp-sourcemaps/map-sources'),
+  identityMap: require('@gulp-sourcemaps/identity-map')
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "Florian Reiterer <me@florianreiterer.com>",
   "license": "ISC",
   "dependencies": {
+    "@gulp-sourcemaps/identity-map": "1.X",
     "@gulp-sourcemaps/map-sources": "1.X",
     "acorn": "4.X",
     "convert-source-map": "1.X",

--- a/src/init/index.js
+++ b/src/init/index.js
@@ -46,6 +46,7 @@ function init(options) {
     }
 
     if (!sourceMap && options.identityMap) {
+      debug(function() { return '**identityMap option is deprecated, update to use sourcemap.identityMap stream**'; });
       debug(function() {
         return 'identityMap';
       });


### PR DESCRIPTION
@nmccready another deprecation.  Should be pretty straightforward (and we've already _dealt_ with the scoped modules problem).