### PR TITLE
Update vinyl dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "git://github.com/gulp-sourcemaps/gulp-sourcemaps.git",
   "main": "index.js",
   "scripts": {
-    "lint": "jshint ./src/**/*.js test/*.js",
+    "lint": "jshint ./src/**/*.js ./test/*.js",
     "test": "npm run lint && faucet test/*.js $@",
     "tape": "tape",
     "cover": "istanbul cover --dir reports/coverage tape \"test/*.js\"",
@@ -34,7 +34,7 @@
     "source-map": "0.X",
     "strip-bom-string": "1.X",
     "through2": "2.X",
-    "vinyl": "1.X"
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "bootstrap": "3.3.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "source-map": "0.X",
     "strip-bom-string": "1.X",
     "through2": "2.X",
-    "vinyl": "^2.1.0"
+    "vinyl": "2.X"
   },
   "devDependencies": {
     "bootstrap": "3.3.7",


### PR DESCRIPTION
Some gulp plugins, amongst which gulp-sourcemaps, are including a very old version of vinyl. This causes problems with differently-shaped vinyl objects going through the gulp pipelines. 