### PR TITLE
Prevent update to source-map 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "debug-fabulous": "1.X",
     "detect-newline": "2.X",
     "graceful-fs": "4.X",
-    "source-map": "0.X",
+    "source-map": "~0.6.0",
     "strip-bom-string": "1.X",
     "through2": "2.X"
   },


### PR DESCRIPTION
source-map 0.7.0 contains a breaking change when using Node.js version < 6. See issue https://github.com/gulp-sourcemaps/gulp-sourcemaps/issues/343.