### PR TITLE
Dependency upgrade css v2.0.0 to v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@gulp-sourcemaps/map-sources": "^1.0.0",
     "acorn": "^6.4.1",
     "convert-source-map": "^1.0.0",
-    "css": "^2.0.0",
+    "css": "^3.0.0",
     "debug-fabulous": "^1.0.0",
     "detect-newline": "^2.0.0",
     "graceful-fs": "^4.0.0",


### PR DESCRIPTION
Major version dependency upgrade of css v2.0.0 to v3.0.0

See https://github.com/lydell/urix#deprecated

Fixes GH-378