### PR TITLE
Replace deprecated Buffer constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ gulp.task('javascript', function() {
 
       // do normal plugin logic
       var result = myTransform(file.contents, options);
-      file.contents = new Buffer(result.code);
+      file.contents = Buffer.from(result.code);
 
       // apply source map to the chain
       if (file.sourceMap) {

--- a/src/init/index.internals.js
+++ b/src/init/index.internals.js
@@ -72,7 +72,7 @@ module.exports = function(options, file, fileContent) {
 
       });
       // remove source map comment from source
-      file.contents = new Buffer(sources.content, 'utf8');
+      file.contents = Buffer.from(sources.content, 'utf8');
     }
 
   }

--- a/src/write/index.internals.js
+++ b/src/write/index.internals.js
@@ -99,7 +99,7 @@ module.exports = function(destPath, options) {
 
     if (destPath === undefined || destPath === null) {
       // encode source map into comment
-      var base64Map = new Buffer(JSON.stringify(sourceMap)).toString('base64');
+      var base64Map = Buffer.from(JSON.stringify(sourceMap)).toString('base64');
       comment = commentFormatter('data:application/json;charset=' + options.charset + ';base64,' + base64Map);
     } else {
       var mapFile = path.join(destPath, file.relative) + '.map';
@@ -130,7 +130,7 @@ module.exports = function(destPath, options) {
 
       var sourceMapFile = file.clone(options.clone || { deep: false, contents: false });
       sourceMapFile.path = sourceMapPath;
-      sourceMapFile.contents = new Buffer(JSON.stringify(sourceMap));
+      sourceMapFile.contents = Buffer.from(JSON.stringify(sourceMap));
       sourceMapFile.stat = {
         isFile: function() { return true; },
         isDirectory: function() { return false; },
@@ -164,7 +164,7 @@ module.exports = function(destPath, options) {
 
     // append source map comment
     if (options.addComment) {
-      file.contents = Buffer.concat([file.contents, new Buffer(comment)]);
+      file.contents = Buffer.concat([file.contents, Buffer.from(comment)]);
     }
   }
 

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -196,7 +196,7 @@ describe('init', function() {
 
   it('should load external source map file referenced in comment with the //# syntax', function(done) {
     var file = helpers.makeFile();
-    file.contents = new Buffer(helpers.sourceContent + '\n//# sourceMappingURL=helloworld2.js.map');
+    file.contents = Buffer.from(helpers.sourceContent + '\n//# sourceMappingURL=helloworld2.js.map');
 
     function assert(results) {
       var data = results[0];
@@ -216,7 +216,7 @@ describe('init', function() {
 
   it('css: should load external source map file referenced in comment with the //*# syntax', function(done) {
     var file = helpers.makeFileCSS();
-    file.contents = new Buffer(helpers.sourceContentCSS + '\n/*# sourceMappingURL=test.css.map */');
+    file.contents = Buffer.from(helpers.sourceContentCSS + '\n/*# sourceMappingURL=test.css.map */');
 
     function assert(results) {
       var data = results[0];
@@ -236,7 +236,7 @@ describe('init', function() {
 
   it('should remove source map comment with the //# syntax', function(done) {
     var file = helpers.makeFile();
-    file.contents = new Buffer(helpers.sourceContent + '\n//# sourceMappingURL=helloworld2.js.map');
+    file.contents = Buffer.from(helpers.sourceContent + '\n//# sourceMappingURL=helloworld2.js.map');
 
     function assert(results) {
       var data = results[0];
@@ -252,7 +252,7 @@ describe('init', function() {
 
   it('init: css: should remove source map comment with the //*# syntax', function(done) {
     var file = helpers.makeFileCSS();
-    file.contents = new Buffer(helpers.sourceContentCSS + '\n/*# sourceMappingURL=test.css.map */');
+    file.contents = Buffer.from(helpers.sourceContentCSS + '\n/*# sourceMappingURL=test.css.map */');
 
     function assert(results) {
       var data = results[0];
@@ -269,7 +269,7 @@ describe('init', function() {
 
   it('should load external source map file referenced in comment with the /*# */ syntax', function(done) {
     var file = helpers.makeFile();
-    file.contents = new Buffer(helpers.sourceContent + '\n/*# sourceMappingURL=helloworld2.js.map */');
+    file.contents = Buffer.from(helpers.sourceContent + '\n/*# sourceMappingURL=helloworld2.js.map */');
 
     function assert(results) {
       var data = results[0];
@@ -289,7 +289,7 @@ describe('init', function() {
 
   it('should remove source map comment with the //# syntax', function(done) {
     var file = helpers.makeFile();
-    file.contents = new Buffer(helpers.sourceContent + '\n/*# sourceMappingURL=helloworld2.js.map */');
+    file.contents = Buffer.from(helpers.sourceContent + '\n/*# sourceMappingURL=helloworld2.js.map */');
 
     function assert(results) {
       var data = results[0];
@@ -325,7 +325,7 @@ describe('init', function() {
 
   it('should load external source map and add sourceContent if missing', function(done) {
     var file = helpers.makeFile();
-    file.contents = new Buffer(helpers.sourceContent + '\n//# sourceMappingURL=helloworld3.js.map');
+    file.contents = Buffer.from(helpers.sourceContent + '\n//# sourceMappingURL=helloworld3.js.map');
 
     function assert(results) {
       var data = results[0];
@@ -345,7 +345,7 @@ describe('init', function() {
 
   it('should not throw when source file for sourceContent not found', function(done) {
     var file = helpers.makeFile();
-    file.contents = new Buffer(helpers.sourceContent + '\n//# sourceMappingURL=helloworld4.js.map');
+    file.contents = Buffer.from(helpers.sourceContent + '\n//# sourceMappingURL=helloworld4.js.map');
 
     function assert(results) {
       var data = results[0];
@@ -384,7 +384,7 @@ describe('init', function() {
 
   it('should use sourceRoot when resolving path to sources', function(done) {
     var file = helpers.makeFile();
-    file.contents = new Buffer(helpers.sourceContent + '\n//# sourceMappingURL=helloworld5.js.map');
+    file.contents = Buffer.from(helpers.sourceContent + '\n//# sourceMappingURL=helloworld5.js.map');
 
     function assert(results) {
       var data = results[0];
@@ -405,7 +405,7 @@ describe('init', function() {
 
   it('should not load source content if the path is a url', function(done) {
     var file = helpers.makeFile();
-    file.contents = new Buffer(helpers.sourceContent + '\n//# sourceMappingURL=helloworld6.js.map');
+    file.contents = Buffer.from(helpers.sourceContent + '\n//# sourceMappingURL=helloworld6.js.map');
 
     function assert(results) {
       var data = results[0];
@@ -477,7 +477,7 @@ describe('init', function() {
     it('should output an error message if debug option is set and sourceContent is missing', function(done) {
 
       var file = helpers.makeFile();
-      file.contents = new Buffer(helpers.sourceContent + '\n//# sourceMappingURL=helloworld4.js.map');
+      file.contents = Buffer.from(helpers.sourceContent + '\n//# sourceMappingURL=helloworld4.js.map');
 
       var history = [];
 
@@ -506,7 +506,7 @@ describe('init', function() {
 
     it('should output an error message if debug option is set, loadMaps: true, and source map file not found', function(done) {
       var file = helpers.makeFile();
-      file.contents = new Buffer(helpers.sourceContent + '\n//# sourceMappingURL=not-existent.js.map');
+      file.contents = Buffer.from(helpers.sourceContent + '\n//# sourceMappingURL=not-existent.js.map');
 
       var history = [];
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -22,7 +22,7 @@ var fs = require('fs');
 var sourceContent = fs.readFileSync(join(__dirname, 'assets/helloworld.js')).toString();
 
 function base64JSON(object) {
-  return 'data:application/json;charset=utf8;base64,' + new Buffer(JSON.stringify(object)).toString('base64');
+  return 'data:application/json;charset=utf8;base64,' + Buffer.from(JSON.stringify(object)).toString('base64');
 }
 
 debug('running');

--- a/test/test-helpers.js
+++ b/test/test-helpers.js
@@ -18,12 +18,12 @@ function makeFile() {
     cwd: __dirname,
     base: path.join(__dirname, 'assets'),
     path: path.join(__dirname, 'assets', 'helloworld.js'),
-    contents: Buffer.from ? Buffer.from(sourceContent) : new Buffer(sourceContent),
+    contents: Buffer.from(sourceContent),
   });
 }
 
 function makeNullFile() {
-  var junkBuffer = new Buffer([]);
+  var junkBuffer = Buffer.alloc(0);
   junkBuffer.toString = function() {
     return null;
   };
@@ -52,7 +52,7 @@ function makeFileWithInlineSourceMap() {
     cwd: __dirname,
     base: path.join(__dirname, 'assets'),
     path: path.join(__dirname, 'assets', 'all.js'),
-    contents: Buffer.from ? Buffer.from(contents) : new Buffer(contents),
+    contents: Buffer.from(contents),
   });
 }
 
@@ -61,7 +61,7 @@ function makeFileCSS() {
     cwd: __dirname,
     base: path.join(__dirname, 'assets'),
     path: path.join(__dirname, 'assets', 'test.css'),
-    contents: Buffer.from ? Buffer.from(sourceContentCSS) : new Buffer(sourceContentCSS),
+    contents: Buffer.from(sourceContentCSS),
   });
 }
 

--- a/test/write.test.js
+++ b/test/write.test.js
@@ -45,7 +45,7 @@ function makeSourceMap(custom) {
 }
 
 function base64JSON(object) {
-  return 'data:application/json;charset=utf8;base64,' + new Buffer(JSON.stringify(object)).toString('base64');
+  return 'data:application/json;charset=utf8;base64,' + Buffer.from(JSON.stringify(object)).toString('base64');
 }
 
 function makeFile(custom) {
@@ -53,7 +53,7 @@ function makeFile(custom) {
     cwd: __dirname,
     base: path.join(__dirname, 'assets'),
     path: path.join(__dirname, 'assets', 'helloworld.js'),
-    contents: new Buffer(sourceContent),
+    contents: Buffer.from(sourceContent),
   });
   file.sourceMap = makeSourceMap(custom);
   return file;
@@ -64,7 +64,7 @@ function makeMappedFile() {
     cwd: __dirname,
     base: path.join(__dirname, 'assets'),
     path: path.join(__dirname, 'assets', 'helloworld.map.js'),
-    contents: new Buffer(mappedContent),
+    contents: Buffer.from(mappedContent),
   });
   file.sourceMap = makeSourceMap({ preExistingComment: utils.getInlinePreExisting(mappedContent) });
   return file;
@@ -75,7 +75,7 @@ function makeNestedFile() {
     cwd: __dirname,
     base: path.join(__dirname, 'assets'),
     path: path.join(__dirname, 'assets', 'dir1', 'dir2', 'helloworld.js'),
-    contents: new Buffer(sourceContent),
+    contents: Buffer.from(sourceContent),
   });
   file.sourceMap = makeSourceMap();
   return file;
@@ -196,7 +196,7 @@ describe('write', function() {
 
   it('should detect whether a file uses \\n or \\r\\n and follow the existing style', function(done) {
     var file = makeFile();
-    file.contents = new Buffer(file.contents.toString().replace(/\n/g, '\r\n'));
+    file.contents = Buffer.from(file.contents.toString().replace(/\n/g, '\r\n'));
 
     function assert(results) {
       var data = results[0];
@@ -212,7 +212,7 @@ describe('write', function() {
 
   it('preExistingComment', function(done) {
     var file = makeMappedFile();
-    file.contents = new Buffer(convert.removeComments(file.contents.toString()));
+    file.contents = Buffer.from(convert.removeComments(file.contents.toString()));
 
     function assert(results) {
       var data = results[0];


### PR DESCRIPTION
The deprecated Buffer constructor has been replaced with `Buffer.from` and `Buffer.alloc`. This removes deprecation warnings when this library is used.

There were some instances where either the Buffer constructor or `Buffer.from` was used, depending on whether `Buffer.from` was defined. But this was unnecessary because the `engines` field of this package ensures that the minimum Node.js version used is 6, which includes the `Buffer.from` method.