### PR TITLE
Replaced dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@gulp-sourcemaps/map-sources": "^1.0.0",
     "acorn": "^6.4.1",
     "convert-source-map": "^1.0.0",
-    "css": "^3.0.0",
+    "css-tree": "^2.2.1",
     "debug-fabulous": "^1.0.0",
     "detect-newline": "^2.0.0",
     "graceful-fs": "^4.0.0",
@@ -57,6 +57,6 @@
     "src"
   ],
   "engines": {
-    "node": ">= 6"
+    "node": ">= 10"
   }
 }

--- a/src/init/index.js
+++ b/src/init/index.js
@@ -5,7 +5,7 @@ var through = require('through2');
 var path = require('path');
 var acorn = require('acorn');
 var SourceMapGenerator = require('source-map').SourceMapGenerator;
-var css = require('css');
+var css = require('css-tree');
 var initInternals = require('./index.internals');
 
 /**
@@ -73,7 +73,7 @@ function init(options) {
         sourceMap = generator.toJSON();
       } else if (fileType === '.css') {
         debug('css');
-        var ast = css.parse(fileContent, { silent: true });
+        var ast = css.parse(fileContent);
         debug(function() {
           return ast;
         });


### PR DESCRIPTION
Replaced css for css-tree, that way we use a mantained project that doesn't depend on source-map-resolve that is deprecated. The package should be version bumped and published to npm.